### PR TITLE
Shared pool members 

### DIFF
--- a/dist/terraform/latest/sccaFirewallTier.json
+++ b/dist/terraform/latest/sccaFirewallTier.json
@@ -36,6 +36,7 @@
                             "serverAddresses": [
                                 "${log_destination}"
                             ],
+                            "shareNodes": true,
                             "enable": true,
                             "servicePort": 514
                         }

--- a/dist/terraform/latest/sccaFirewallTier.json
+++ b/dist/terraform/latest/sccaFirewallTier.json
@@ -273,7 +273,8 @@
                             "servicePort": 3389,
                             "serverAddresses": [
                                 "${rdp_pool_addresses}"
-                            ]
+                            ],
+                            "shareNodes": true
                         }
                     ],
                     "monitors": [
@@ -290,7 +291,8 @@
                             "servicePort": 22,
                             "serverAddresses": [
                                 "${ssh_pool_addresses}"
-                            ]
+                            ],
+                            "shareNodes": true
                         }
                     ],
                     "monitors": [
@@ -496,7 +498,8 @@
                             "servicePort": 443,
                             "serverAddresses": [
                                 "${ips_pool_addresses}"
-                            ]
+                            ],
+                            "shareNodes": true
                         }
                     ],
                     "class": "Pool"
@@ -513,7 +516,8 @@
                             "servicePort": 3000,
                             "serverAddresses": [
                                 "${app_pool_addresses}"
-                            ]
+                            ],
+                            "shareNodes": true
                         }
                     ],
                     "class": "Pool"
@@ -531,7 +535,8 @@
                             "servicePort": 8080,
                             "serverAddresses": [
                                 "${log_destination}"
-                            ]
+                            ],
+                            "shareNodes": true
                         }
                     ],
                     "class": "Pool"
@@ -548,7 +553,8 @@
                             "servicePort":443,
                             "serverAddresses": [
                                 "${app_pool_addresses}"
-                            ]
+                            ],
+                            "shareNodes": true
                         }
                     ],
                     "class": "Pool"
@@ -565,7 +571,8 @@
                             "servicePort":80,
                             "serverAddresses": [
                                 "${app_pool_addresses}"
-                            ]
+                            ],
+                            "shareNodes": true
                         }
                     ],
                     "class": "Pool"

--- a/dist/terraform/latest/sccaSingleTier.json
+++ b/dist/terraform/latest/sccaSingleTier.json
@@ -36,6 +36,7 @@
                             "serverAddresses": [
                                 "${log_destination}"
                             ],
+                            "shareNodes": true,
                             "enable": true,
                             "servicePort": 514
                         }

--- a/dist/terraform/latest/sccaSingleTier.json
+++ b/dist/terraform/latest/sccaSingleTier.json
@@ -273,7 +273,8 @@
                             "servicePort": 3389,
                             "serverAddresses": [
                                 "${rdp_pool_addresses}"
-                            ]
+                            ],
+                            "shareNodes": true
                         }
                     ],
                     "monitors": [
@@ -290,7 +291,8 @@
                             "servicePort": 22,
                             "serverAddresses": [
                                 "${ssh_pool_addresses}"
-                            ]
+                            ],
+                            "shareNodes": true
                         }
                     ],
                     "monitors": [
@@ -496,7 +498,8 @@
                             "servicePort": 443,
                             "serverAddresses": [
                                 "${ips_pool_addresses}"
-                            ]
+                            ],
+                            "shareNodes": true
                         }
                     ],
                     "class": "Pool"
@@ -513,7 +516,8 @@
                             "servicePort": 3000,
                             "serverAddresses": [
                                 "${app_pool_addresses}"
-                            ]
+                            ],
+                            "shareNodes": true
                         }
                     ],
                     "class": "Pool"
@@ -531,7 +535,8 @@
                             "servicePort": 8080,
                             "serverAddresses": [
                                 "${log_destination}"
-                            ]
+                            ],
+                            "shareNodes": true
                         }
                     ],
                     "class": "Pool"
@@ -548,7 +553,8 @@
                             "servicePort":443,
                             "serverAddresses": [
                                 "${app_pool_addresses}"
-                            ]
+                            ],
+                            "shareNodes": true
                         }
                     ],
                     "class": "Pool"
@@ -565,7 +571,8 @@
                             "servicePort":80,
                             "serverAddresses": [
                                 "${app_pool_addresses}"
-                            ]
+                            ],
+                            "shareNodes": true
                         }
                     ],
                     "class": "Pool"

--- a/dist/terraform/latest/sccaWAFTier.json
+++ b/dist/terraform/latest/sccaWAFTier.json
@@ -36,6 +36,7 @@
                             "serverAddresses": [
                                 "${log_destination}"
                             ],
+                            "shareNodes": true,
                             "enable": true,
                             "servicePort": 514
                         }

--- a/dist/terraform/latest/sccaWAFTier.json
+++ b/dist/terraform/latest/sccaWAFTier.json
@@ -273,7 +273,8 @@
                             "servicePort": 3389,
                             "serverAddresses": [
                                 "${rdp_pool_addresses}"
-                            ]
+                            ],
+                            "shareNodes": true
                         }
                     ],
                     "monitors": [
@@ -290,7 +291,8 @@
                             "servicePort": 22,
                             "serverAddresses": [
                                 "${ssh_pool_addresses}"
-                            ]
+                            ],
+                            "shareNodes": true
                         }
                     ],
                     "monitors": [
@@ -496,7 +498,8 @@
                             "servicePort": 443,
                             "serverAddresses": [
                                 "${ips_pool_addresses}"
-                            ]
+                            ],
+                            "shareNodes": true
                         }
                     ],
                     "class": "Pool"
@@ -513,7 +516,8 @@
                             "servicePort": 3000,
                             "serverAddresses": [
                                 "${app_pool_addresses}"
-                            ]
+                            ],
+                            "shareNodes": true
                         }
                     ],
                     "class": "Pool"
@@ -531,7 +535,8 @@
                             "servicePort": 8080,
                             "serverAddresses": [
                                 "${log_destination}"
-                            ]
+                            ],
+                            "shareNodes": true
                         }
                     ],
                     "class": "Pool"
@@ -548,7 +553,8 @@
                             "servicePort":443,
                             "serverAddresses": [
                                 "${app_pool_addresses}"
-                            ]
+                            ],
+                            "shareNodes": true
                         }
                     ],
                     "class": "Pool"
@@ -565,7 +571,8 @@
                             "servicePort":80,
                             "serverAddresses": [
                                 "${app_pool_addresses}"
-                            ]
+                            ],
+                            "shareNodes": true
                         }
                     ],
                     "class": "Pool"


### PR DESCRIPTION
The "shareNodes": True flags are required when the pool's corresponding member IP address is used in another pool. The resulting error is logged in the /var/log/restnoded/restnoded.log files as follows:

`Tue, 26 Sep 2023 13:26:42 GMT - severe: [appsvcs] {"message":"Declaration failed: 0107176c:3: Invalid Node, the IP address 10.90.6.13 already exists.","level":"error"}`